### PR TITLE
assetstools backend: include base monobehaviour fields

### DIFF
--- a/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetsTools/AssetsToolsGenerator.cs
+++ b/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetsTools/AssetsToolsGenerator.cs
@@ -47,10 +47,69 @@ namespace TypeTreeGeneratorAPI.TypeTreeGenerator.AssetsTools
                 Name = "Base",
                 Type = className,
                 ValueType = AssetValueType.None,
-                IsArray = false,
-                IsAligned = false,
-                HasValue = false,
-                Children = new List<AssetTypeTemplateField>(0)
+                Children = [
+                    new AssetTypeTemplateField {
+                        Name = "m_GameObject",
+                        Type = "PPtr<GameObject>",
+                        Children = [
+                            new AssetTypeTemplateField {
+                                Name = "m_FileID",
+                                Type = "int",
+                                Children = [],
+                            },
+                            new AssetTypeTemplateField {
+                                Name = "m_PathID",
+                                Type = "SInt64",
+                                Children = [],
+                            },
+                        ],
+                    },
+                    new AssetTypeTemplateField {
+                        Name = "m_Enabled",
+                        Type = "UInt8",
+                        IsAligned = true,
+                        Children = [],
+                    },
+                    new AssetTypeTemplateField {
+                        Name = "m_Script",
+                        Type = "PPtr<MonoScript>",
+                        Children = [
+                            new AssetTypeTemplateField {
+                                Name = "m_FileID",
+                                Type = "int",
+                                Children = [],
+                            },
+                            new AssetTypeTemplateField {
+                                Name = "m_PathID",
+                                Type = "SInt64",
+                                Children = [],
+                            },
+                        ],
+                    },
+                    new AssetTypeTemplateField {
+                        Name = "m_Name",
+                        Type = "string",
+                        Children = [
+                            new AssetTypeTemplateField {
+                                Name = "Array",
+                                Type = "Array",
+                                IsAligned = true,
+                                Children = [
+                                    new AssetTypeTemplateField {
+                                        Name = "size",
+                                        Type = "int",
+                                        Children = [],
+                                    },
+                                    new AssetTypeTemplateField {
+                                        Name = "data",
+                                        Type = "char",
+                                        Children = [],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
             };
 
             IMonoBehaviourTemplateGeneratorPatch monoTemplateGenerator = monoLoaded ? monoCecilGenerator : cpp2IlGenerator;


### PR DESCRIPTION
The `AssetStudio` backend includes the monobehaviour base fields in the generated types, but the `AssetsTools` backend doesn't.
This PR adds them to `AssetsTools`, but hardcoded. Maybe it should use the tpk class database, I'm not sure.

The alternatives would be to 
- never include monobehaviour base fields (dependencies like UnityPy would have to change their reading code)
- make it configurable

I don't have a strong opinion on the matter, as long as it's consistent.