### PR TITLE
Backend consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Rider
+/.idea
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetRipper/AssetRipper.cs
+++ b/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetRipper/AssetRipper.cs
@@ -26,8 +26,9 @@ namespace TypeTreeGeneratorAPI.TypeTreeGenerator.AssetRipper
             var nameSpace = lastDot == -1 ? "" : fullName.Substring(0, lastDot);
             var className = lastDot == -1 ? fullName : fullName.Substring(lastDot + 1);
 
+            var assemblyNameNormalized = assemblyName.EndsWith(".dll") ? assemblyName[..^".dll".Length] : assemblyName;
 
-            var type = FindType(assemblyName, nameSpace, className);
+            var type = FindType(assemblyNameNormalized, nameSpace, className);
             if (type == null)
             {
                 return null;

--- a/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetStudio/AssetStudioGenerator.cs
+++ b/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetStudio/AssetStudioGenerator.cs
@@ -48,7 +48,9 @@ namespace TypeTreeGeneratorAPI.TypeTreeGenerator.AssetStudio
 
         public override List<TypeTreeNode>? GenerateTreeNodes(string assemblyName, string fullName)
         {
-            var typeDef = GetTypeDefinition(assemblyName, fullName);
+            var assemblyNameNormalized = assemblyName.EndsWith(".dll") ? assemblyName : $"{assemblyName}.dll";
+            
+            var typeDef = GetTypeDefinition(assemblyNameNormalized, fullName);
             if (typeDef != null)
             {
                 return GenerateTreeNodes(typeDef);

--- a/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetStudio/AssetStudioGenerator.cs
+++ b/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetStudio/AssetStudioGenerator.cs
@@ -80,12 +80,8 @@ namespace TypeTreeGeneratorAPI.TypeTreeGenerator.AssetStudio
 
         private List<TypeTreeNode> GenerateTreeNodes(TypeDefinition typeDef)
         {
-            //  from AssetStudioUtility.MonoBehaviourConverter
-            var m_Nodes = new List<TypeTreeNode>();
-            serializedTypeHelper.AddMonoBehaviour(m_Nodes, 0);
             var converter = new TypeDefinitionConverter(typeDef, serializedTypeHelper, 1);
-            m_Nodes.AddRange(converter.ConvertToTypeTreeNodes());
-            return m_Nodes;
+            return converter.ConvertToTypeTreeNodes();
         }
 
         private TypeDefinition? GetTypeDefinition(string assemblyName, string fullName)

--- a/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetStudio/AssetStudioUtility/SerilizedTypeHelper.cs
+++ b/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetStudio/AssetStudioUtility/SerilizedTypeHelper.cs
@@ -9,15 +9,6 @@
             this.version = version;
         }
 
-        public void AddMonoBehaviour(List<TypeTreeNode> nodes, int indent)
-        {
-            nodes.Add(new TypeTreeNode("MonoBehaviour", "Base", indent, false));
-            AddPPtr(nodes, "GameObject", "m_GameObject", indent + 1);
-            nodes.Add(new TypeTreeNode("UInt8", "m_Enabled", indent + 1, true));
-            AddPPtr(nodes, "MonoScript", "m_Script", indent + 1);
-            AddString(nodes, "m_Name", indent + 1);
-        }
-
         public void AddPPtr(List<TypeTreeNode> nodes, string type, string name, int indent)
         {
             nodes.Add(new TypeTreeNode($"PPtr<{type}>", name, indent, false));


### PR DESCRIPTION
alternative to #3 
- removes the `Monobehaviour` base fields from the `AssetStudio` backend (in line with the other two)
- make every backend accept both `Assembly-CSharp` and `Assembly-CSharp.dll`