### PR TITLE
Return `nullptr` on missing type instead of `-1` error

### DIFF
--- a/TypeTreeGeneratorAPI/NativeAPI.cs
+++ b/TypeTreeGeneratorAPI/NativeAPI.cs
@@ -7,7 +7,7 @@ namespace TypeTreeGeneratorAPI
     public static class NativeAPI
     {
         [UnmanagedCallersOnly(EntryPoint = "TypeTreeGenerator_init")]
-        public static IntPtr TypeTreeGenerator_create(IntPtr unityVersionPtr, IntPtr generatorName)
+        public static IntPtr TypeTreeGenerator_init(IntPtr unityVersionPtr, IntPtr generatorName)
         {
             string? unityVersion = Marshal.PtrToStringUTF8(unityVersionPtr);
             string? generatorNameStr = Marshal.PtrToStringUTF8(generatorName);
@@ -92,7 +92,7 @@ namespace TypeTreeGeneratorAPI
         }
 
         [UnmanagedCallersOnly(EntryPoint = "TypeTreeGenerator_del")]
-        public static int TypeTreeGenerator_delete(IntPtr typeTreeGeneratorPtr)
+        public static int TypeTreeGenerator_del(IntPtr typeTreeGeneratorPtr)
         {
             if (typeTreeGeneratorPtr == IntPtr.Zero)
             {
@@ -113,7 +113,7 @@ namespace TypeTreeGeneratorAPI
         }
 
         [UnmanagedCallersOnly(EntryPoint = "TypeTreeGenerator_getLoadedDLLNames")]
-        public static IntPtr TypeTreeGenerator_generateTypeTreeNodesJson(IntPtr typeTreeGeneratorPtr)
+        public static IntPtr TypeTreeGenerator_getLoadedDLLNames(IntPtr typeTreeGeneratorPtr)
         {
             if (typeTreeGeneratorPtr == IntPtr.Zero)
             {
@@ -130,7 +130,7 @@ namespace TypeTreeGeneratorAPI
         }
 
         [UnmanagedCallersOnly(EntryPoint = "TypeTreeGenerator_generateTreeNodesJson")]
-        public static int TypeTreeGenerator_generateTypeTreeNodesJson(IntPtr typeTreeGeneratorPtr, IntPtr assemblyNamePtr, IntPtr fullNamePtr, IntPtr jsonAddr)
+        public static int TypeTreeGenerator_generateTreeNodesJson(IntPtr typeTreeGeneratorPtr, IntPtr assemblyNamePtr, IntPtr fullNamePtr, IntPtr jsonAddr)
         {
             string? assemblyName = Marshal.PtrToStringUTF8(assemblyNamePtr);
             string? fullName = Marshal.PtrToStringUTF8(fullNamePtr);
@@ -160,7 +160,7 @@ namespace TypeTreeGeneratorAPI
         }
 
         [UnmanagedCallersOnly(EntryPoint = "TypeTreeGenerator_generateTreeNodesRaw")]
-        public static int TypeTreeGenerator_generateTypeTreeNodesRaw(IntPtr typeTreeGeneratorPtr, IntPtr assemblyNamePtr, IntPtr fullNamePtr, IntPtr arrAddrPtr, IntPtr arrLengthPtr)
+        public static int TypeTreeGenerator_generateTreeNodesRaw(IntPtr typeTreeGeneratorPtr, IntPtr assemblyNamePtr, IntPtr fullNamePtr, IntPtr arrAddrPtr, IntPtr arrLengthPtr)
         {
             string? assemblyName = Marshal.PtrToStringUTF8(assemblyNamePtr);
             string? fullName = Marshal.PtrToStringUTF8(fullNamePtr);

--- a/TypeTreeGeneratorAPI/NativeAPI.cs
+++ b/TypeTreeGeneratorAPI/NativeAPI.cs
@@ -146,7 +146,8 @@ namespace TypeTreeGeneratorAPI
                 var typeTreeNodes = handle.Instance.GenerateTreeNodes(assemblyName, fullName);
                 if (typeTreeNodes == null)
                 {
-                    return -1;
+                    Marshal.WriteIntPtr(jsonAddr, IntPtr.Zero);
+                    return 0;
                 }
                 var json = TypeTreeNodeSerializer.ToJson(typeTreeNodes!);
                 Marshal.WriteIntPtr(jsonAddr, Marshal.StringToCoTaskMemUTF8(json));
@@ -175,7 +176,9 @@ namespace TypeTreeGeneratorAPI
                 var typeTreeNodes = handle.Instance.GenerateTreeNodes(assemblyName, fullName);
                 if (typeTreeNodes == null)
                 {
-                    return -1;
+                    Marshal.WriteIntPtr(arrAddrPtr, IntPtr.Zero);
+                    Marshal.WriteInt32(arrLengthPtr, 0);
+                    return 0;
                 }
                 var (arrayPtr, arrayLength) = TypeTreeNodeSerializer.ToRaw(typeTreeNodes!);
 

--- a/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetsTools/MonoBehaviourTemplateGeneratorPatch.cs
+++ b/TypeTreeGeneratorAPI/TypeTreeGenerator/AssetsTools/MonoBehaviourTemplateGeneratorPatch.cs
@@ -7,7 +7,7 @@ namespace TypeTreeGeneratorAPI.TypeTreeGenerator.AssetsTools
 {
     public interface IMonoBehaviourTemplateGeneratorPatch : IMonoBehaviourTemplateGenerator
     {
-        virtual AssetTypeTemplateField GetTemplateFieldPatch(AssetTypeTemplateField templateField, string assemblyName, string nameSpace, string className, UnityVersion unityVersionExtra)
+        virtual AssetTypeTemplateField? GetTemplateFieldPatch(AssetTypeTemplateField templateField, string assemblyName, string nameSpace, string className, UnityVersion unityVersionExtra)
         {
             return GetTemplateField(templateField, assemblyName, nameSpace, className, unityVersionExtra);
         }
@@ -40,7 +40,7 @@ namespace TypeTreeGeneratorAPI.TypeTreeGenerator.AssetsTools
         {
         }
 
-        public AssetTypeTemplateField GetTemplateFieldPatch(AssetTypeTemplateField baseField, string assemblyName, string nameSpace, string className, UnityVersion unityVersion)
+        public AssetTypeTemplateField? GetTemplateFieldPatch(AssetTypeTemplateField baseField, string assemblyName, string nameSpace, string className, UnityVersion unityVersion)
         {
             // 1:1 copy of the original method, but without filepath check and using the loadedAssemblies dictionary
             if (!assemblyName.EndsWith(".dll"))
@@ -50,6 +50,10 @@ namespace TypeTreeGeneratorAPI.TypeTreeGenerator.AssetsTools
             var asm = loadedAssemblies[assemblyName];
 
             List<AssetTypeTemplateField> newFields = Read(asm, nameSpace, className, unityVersion);
+            if (newFields == null)
+            {
+                return null;
+            }
 
             AssetTypeTemplateField newBaseField = baseField.Clone();
             newBaseField.Children.AddRange(newFields);


### PR DESCRIPTION
When encountering a `Assembly`, `TypeName` pair that doesn't exist, return a nullptr instead of failing with -1.

Alternatively you could fail with -2 or another distinct failure code. I'd just like to be able to distinguish failure (couldn't generate a type, report error) from unknown type (which can happen if the scripts reference editor-only types).