### PR TITLE
build: use `libTypeTreeGenerator.{so,dylib}` naming convention on linux,macOS

### DIFF
--- a/TypeTreeGeneratorAPI/TypeTreeGeneratorAPI.csproj
+++ b/TypeTreeGeneratorAPI/TypeTreeGeneratorAPI.csproj
@@ -8,6 +8,9 @@
 	  <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 	  <InvariantGlobalization>true</InvariantGlobalization>
 	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+	  
+	  <TargetName>$(MSBuildProjectName)</TargetName>
+	  <TargetName Condition="'$(OS)' != 'Windows_NT'">lib$(TargetName)</TargetName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/bindings/python/TypeTreeGeneratorAPI/TypeTreeGenerator.py
+++ b/bindings/python/TypeTreeGeneratorAPI/TypeTreeGenerator.py
@@ -40,10 +40,10 @@ def init_dll(asm_path: Optional[str] = None):
         fp = asm_path or os.path.join(LOCAL, "TypeTreeGeneratorAPI.dll")
         dll = ctypes.WinDLL(fp)
     elif system == "Linux":
-        fp = asm_path or os.path.join(LOCAL, "TypeTreeGeneratorAPI.so")
+        fp = asm_path or os.path.join(LOCAL, "libTypeTreeGeneratorAPI.so")
         dll = ctypes.CDLL(fp)
     elif system == "Darwin":
-        fp = asm_path or os.path.join(LOCAL, "TypeTreeGeneratorAPI.dylib")
+        fp = asm_path or os.path.join(LOCAL, "libTypeTreeGeneratorAPI.dylib")
         dll = ctypes.CDLL(fp)
     else:
         raise NotImplementedError(f"TypeTreeGenerator doesn't support {system}!")


### PR DESCRIPTION
The `lib` prefix is commonly expected to be present on linux and macOS, e.g. in rust build scripts:
```
println!("cargo:rustc-link-lib=dylib=TypeTreeGeneratorAPI");
```
or c compilers (`gcc -lTypeTreeGeneratorAPI` links `libTypeTreeGeneratorAPI`).
